### PR TITLE
build: allow overriding DISABLE_IF_EXISTS via environment variable

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 name := 'cosmic-initial-setup'
 export APPID := 'com.system76.CosmicInitialSetup'
-export DISABLE_IF_EXISTS := '/cdrom/casper/filesystem.squashfs'
+export DISABLE_IF_EXISTS := env('DISABLE_IF_EXISTS', '/cdrom/casper/filesystem.squashfs')
 
 rootdir := ''
 prefix := '/usr'


### PR DESCRIPTION
I am packaging COSMIC Beta for NixOS in (NixOS/nixpkgs#440950) needs to override this variable to point to the correct path