### PR TITLE
Add configure.py script for easier distro configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /target/
 /vendor.tar
 /vendor/
+.distro_config.env

--- a/configure.py
+++ b/configure.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+
+def get_parser():
+    parser = argparse.ArgumentParser(description='Configure script for Cosmic packages')
+
+    # Build options
+    build_opt = parser.add_argument_group('build', 'Build options')
+    build_opt.add_argument('-j', '--jobs', default='0', type=int,
+                            help='Maximum number of concurrent jobs while building (0 means use all cores) (default: %(default)s)')
+
+    # Layout options
+    layout_opt = parser.add_argument_group('layout', 'Package layout options')
+    layout_opt.add_argument('--bindir', default='/usr/bin', help='Directory where user-invoked binaries should be installed (default: %(default)s)')
+    layout_opt.add_argument('--sbindir', default='/usr/sbin', help='Directory where superuser-invoked binaries should be installed (default: %(default)s)')
+    layout_opt.add_argument('--libexecdir', default='/usr/libexec', help='Directory where binaries that will be invoked by other applications should be installed (default: %(default)s)')
+    layout_opt.add_argument('--libdir', default='/usr/lib', help='Directory where libraries should be installed (default: %(default)s)')
+    layout_opt.add_argument('--includedir', default='/usr/include', help='Directory where header files should be installed (default: %(default)s)')
+    layout_opt.add_argument('--datadir', default='/usr/share', help='Directory where data files should be installed (default: %(default)s)')
+    layout_opt.add_argument('--mandir', default='/usr/share/man', help='Directory where man pages be installed (default: %(default)s)')
+    layout_opt.add_argument('--polkitdir', default='/usr/share/polkit-1', help='Directory where polkit configuration should be installed (default: %(default)s)')
+    layout_opt.add_argument('--systemddir', default='/usr/lib/systemd', help='Directory where systemd service files and units should be installed (default: %(default)s)')
+    layout_opt.add_argument('--sysconfdir', default='/etc', help='Directory where system config files should be installed (default: %(default)s)')
+    layout_opt.add_argument('--xdgdir', default='/etc/xdg', help='Directory where XDG data files be installed (default: %(default)s)')
+    layout_opt.add_argument('--pamconfdir', default='/etc/pam.d', help='Directory where PAM configuration should be installed (default: %(default)s)')
+    layout_opt.add_argument('--statedir', default='/var/lib', help='Directory where system state should be stored (default: %(default)s)')
+
+    # Install options
+    install_opt = parser.add_argument_group('install', 'Package installation options')
+    install_opt.add_argument('--installdir', default='/', help='Root directory where all files should be installed (for packaging) (default: %(default)s)')
+
+    return parser
+
+distro_conf_contents = \
+"""### Managed by configure.py script, do not manually edit
+"""
+
+if __name__ == '__main__':
+    parser = get_parser()
+    args = parser.parse_args()
+
+    for key, var in vars(args).items():
+        distro_conf_contents += "DISTRO_" + key.upper() + "=\"" + str(var) + "\"\n"
+
+    # Get the path to this script
+    root_dir = Path(__file__).parent
+    distro_conf_f = root_dir / ".distro_config.env"
+
+    with open(distro_conf_f, "w") as f:
+        f.write(distro_conf_contents)
+
+    print(".distro_config.env successfully generated")

--- a/justfile
+++ b/justfile
@@ -1,35 +1,50 @@
+set dotenv-load
+set dotenv-filename := ".distro_config.env"
+
 name := 'cosmic-initial-setup'
 export APPID := 'com.system76.CosmicInitialSetup'
 export DISABLE_IF_EXISTS := env('DISABLE_IF_EXISTS', '/cdrom/casper/filesystem.squashfs')
 
-rootdir := ''
 prefix := '/usr'
 
-base-dir := absolute_path(clean(rootdir / prefix))
+# Settings that can be overridden/managed by configure.py
+build-jobs := if env('DISTRO_JOBS') == '0' { 'default' } else { env('DISTRO_JOBS') }
+install-dir := env('DISTRO_INSTALLDIR', '')
+bin-dir := env('DISTRO_BINDIR', prefix / 'bin')
+data-dir := env('DISTRO_DATADIR', prefix / 'share')
+sysconf-dir := env('DISTRO_SYSCONFDIR', 'etc')
+xdg-dir := env('DISTRO_XDGDIR', sysconf-dir / 'xdg')
+polkit-dir := env('DISTRO_POLKITDIR', data-dir / 'polkit-1')
+
 cargo-target-dir := env('CARGO_TARGET_DIR', 'target')
 bin-src := cargo-target-dir / 'release' / name
-bin-dst := base-dir / 'bin' / name
-icons-dir := base-dir / 'share' / 'icons' / 'hicolor' / 'scalable' / 'apps'
+bin-dst := install-dir / bin-dir / name
+icons-dir := data-dir / 'icons' / 'hicolor' / 'scalable' / 'apps'
 
 polkit-rules-src := 'res' / '20-cosmic-initial-setup.rules'
-polkit-rules-dst := base-dir / 'share' / 'polkit-1' / 'rules.d' / '20-cosmic-initial-setup.rules'
+polkit-rules-dst := install-dir / polkit-dir / 'rules.d' / '20-cosmic-initial-setup.rules'
 
 desktop-entry := APPID + '.desktop'
 desktop-src := 'res' / desktop-entry
-desktop-dst := base-dir / 'share' / 'applications' / desktop-entry
+desktop-dst := install-dir / data-dir / 'applications' / desktop-entry
 
 icon-src := 'res' / 'icon.svg'
-icon-dst := icons-dir / APPID + '.svg'
+icon-dst := install-dir / icons-dir / APPID + '.svg'
 
 autostart-entry := APPID + '.Autostart.desktop'
 autostart-src := 'res' / autostart-entry
-autostart-dst := rootdir / 'etc' / 'xdg' / 'autostart' / desktop-entry
+autostart-dst := install-dir / xdg-dir / 'autostart' / desktop-entry
 
 layouts-src := 'res' / 'layouts'
-layouts-dst := base-dir / 'share' / 'cosmic-layouts'
+layouts-dir := data-dir / 'cosmic-layouts'
+layouts-dst := install-dir / layouts-dir
+
+export COSMIC_LAYOUTS_DIR := layouts-dir
 
 themes-src := 'res' / 'themes'
-themes-dst := base-dir / 'share' / 'cosmic' / 'cosmic-themes'
+themes-dst := install-dir / data-dir / 'cosmic' / 'cosmic-themes'
+
+export CARGO_BUILD_JOBS := build-jobs
 
 # Default recipe which runs `just build-release`
 default: build-release

--- a/src/page/layout.rs
+++ b/src/page/layout.rs
@@ -64,7 +64,8 @@ impl super::Page for Page {
     }
 
     fn init(&mut self) -> cosmic::Task<super::Message> {
-        let Ok(layouts_dir) = std::fs::read_dir("/usr/share/cosmic-layouts/") else {
+        let build_time_dir: Option<&'static str> = option_env!("COSMIC_LAYOUTS_DIR");
+        let Ok(layouts_dir) = std::fs::read_dir(build_time_dir.unwrap_or("/usr/share/cosmic-layouts/")) else {
             return cosmic::Task::none();
         };
 


### PR DESCRIPTION
Distros usually have different policies for where various package contents should be installed. For instance Fedora installs all user binaries to /usr/bin and has /usr/sbin as a symlink to that while AerynOS and Solus (Arch too I think) don't use /usr/libexec at all and switch those binaries to /usr/lib/some-package-specific-identifier. Some distros follow the hermetic-usr approach and forbid packages from shipping any files outside of /usr and so have alternate /usr destinations for files that typically go in /etc (for example).

Currently packaging is very awkward for distributions that diverge from the "Ubuntu" layout as they need to have downstream patches for the justfiles or custom installation phases in order to get the packages to conform to distro policy which generates a lot of extra work to keep all Cosmic packages in sync.

Instead let's adopt the approach that autotools/meson/cmake use and split out package configuration to an earlier step, and then reuse that configuration for the build and install phases. Do this by adding a configure.py script which accepts common distribution options and which then writes a `.distro_config.env` file. The justfile can then use this .env for the various build settings and installation locations, with default settings for if the .env file is not present (allowing running configure.py to be optional).

By doing this we allow packagers to create common macros which can be shared and used by all cosmic packages and which should be less error-prone than having to keep a set of patches in sync.