### PR TITLE
fix(layout): do not preserve anything

### DIFF
--- a/src/page/layout.rs
+++ b/src/page/layout.rs
@@ -245,6 +245,7 @@ fn apply_layout(path: &Path) {
             // Copy layout to local config
             _ = std::process::Command::new("cp")
                 .arg("-r")
+                .arg("--no-preserve=all")
                 .arg(&path)
                 .arg(&config_dest_path)
                 .status();


### PR DESCRIPTION
This makes the layouts read-only and it cannot be modified by cosmic-settings or by the user itself.