### PR TITLE
fix(keyboard): make layout search case-insensitive

### DIFF
--- a/src/page/appearance.rs
+++ b/src/page/appearance.rs
@@ -1,9 +1,10 @@
 use cosmic::{
+    Element, Task,
     cosmic_config::{Config, ConfigSet, CosmicConfigEntry},
     cosmic_theme::{self, ThemeBuilder, ThemeMode},
     iced::{Alignment, Length},
     theme::{self, ThemeType},
-    widget, Element, Task,
+    widget,
 };
 use heck::ToTitleCase;
 use std::{collections::BTreeSet, sync::Arc};

--- a/src/page/keyboard.rs
+++ b/src/page/keyboard.rs
@@ -1,12 +1,6 @@
 use std::cmp;
 
-use cosmic::{
-    Element, Task,
-    cosmic_config::{self, ConfigGet, ConfigSet},
-    cosmic_theme,
-    iced::Alignment,
-    theme, widget,
-};
+use cosmic::{Element, Element, Task, Task, cosmic_theme, iced::Alignment, theme, widget};
 use cosmic_comp_config::{KeyboardConfig, XkbConfig};
 use slotmap::{DefaultKey, SlotMap};
 
@@ -283,7 +277,11 @@ impl page::Page for Page {
         let mut list = widget::list_column();
 
         for (id, (_locale, variant, description, _source)) in &self.keyboard_layouts {
-            if self.search.is_empty() || description.to_lowercase().contains(&self.search) {
+            if self
+                .regex_opt
+                .as_ref()
+                .is_none_or(|re| re.is_match(description))
+            {
                 let selected = Some(id) == self.selected_opt;
                 let item = widget::settings::item::builder(description).control(
                     widget::row::with_children(vec![


### PR DESCRIPTION
The keyboard layout search was case-sensitive because it was comparing the lowercased layout description with the search term as-is.

This change fixes the issue by using the `regex_opt` field, which holds a pre-compiled case-insensitive regex of the search term, to filter the layouts. This ensures the search is case-insensitive as intended.

I also ran `cargo fmt` to fix some formatting issues I've made in previous PRs

Closes #55