### PR TITLE
fix(wifi): make network list scrollable

### DIFF
--- a/src/page/wifi.rs
+++ b/src/page/wifi.rs
@@ -218,12 +218,18 @@ impl super::Page for Page {
                 },
             );
 
-            if has_known {
-                view = view.push(known_networks);
-            }
+            if has_known || has_visible {
+                let mut networks = widget::column().spacing(spacing.space_l);
 
-            if has_visible {
-                view = view.push(visible_networks);
+                if has_known {
+                    networks = networks.push(known_networks);
+                }
+
+                if has_visible {
+                    networks = networks.push(visible_networks);
+                }
+
+                view = view.push(widget::scrollable(networks));
             }
         };
 


### PR DESCRIPTION
The list of networks on the initial setup screen was not scrollable. If the number of networks exceeded the available screen height, some networks were not visible or accessible.

Closes #57 