### PR TITLE
toolchain: update to 1.90 + update crabtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.85"
 
 [dependencies]
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols" }
-crabtime = "1.1.3"
+crabtime = "1.1.4"
 eyre = "0.6.12"
 futures = "0.3.31"
 futures-util = "0.3.31"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.90"


### PR DESCRIPTION
### Description
Same reasons as [#1863](https://github.com/pop-os/cosmic-comp/pull/1863).

Also, updated crabtime to version 1.1.4 to accomodate for changes (1.1.3 does not support 1.85).