### PR TITLE
fix(nixos): use correct process name

### DIFF
--- a/src/page/layout.rs
+++ b/src/page/layout.rs
@@ -280,11 +280,7 @@ fn apply_layout(path: &Path) {
         }
     }
 
-    #[cfg(not(feature = "nixos"))]
-    let panel_process = "cosmic-panel";
-    #[cfg(feature = "nixos")]
-    let panel_process = ".cosmic-panel-wrapped";
     _ = std::process::Command::new("killall")
-        .arg(panel_process)
+        .arg("cosmic-panel")
         .status();
 }


### PR DESCRIPTION
In latest nixos-unstable `cosmic-panel` (or any cosmic tool for that matter) is no longer wrapped and is running under `cosmic-panel`.
This essentially reverts the change done in [d2623cb](https://github.com/pop-os/cosmic-initial-setup/commit/d2623cb0c61877e648a5362f1b1be6dc6e091cbb)

Tested manually on NixOS using an overlay for the `cosmic-initial-setup` package

- [ ] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

