### PR TITLE
fix: alignment

### DIFF
--- a/src/page/keyboard.rs
+++ b/src/page/keyboard.rs
@@ -1,7 +1,7 @@
 use std::cmp;
 
 use cosmic::cosmic_config::{self, ConfigGet, ConfigSet};
-use cosmic::iced::Alignment;
+use cosmic::iced::{Alignment, Length};
 use cosmic::{Element, Task, cosmic_theme, theme, widget};
 use cosmic_comp_config::{KeyboardConfig, XkbConfig};
 use slotmap::{DefaultKey, SlotMap};
@@ -302,6 +302,7 @@ impl page::Page for Page {
 
                 //TODO: properly style this
                 let input_source = widget::button::custom(item)
+                    .width(Length::Fill)
                     .on_press(Message::Select(id))
                     .class(if selected {
                         theme::Button::Link

--- a/src/page/language.rs
+++ b/src/page/language.rs
@@ -1,5 +1,5 @@
 use cosmic::cosmic_config::{self, ConfigSet};
-use cosmic::iced::Alignment;
+use cosmic::iced::{Alignment, Length};
 use cosmic::{Element, Task, cosmic_theme, theme, widget};
 use eyre::Context;
 use slotmap::{DefaultKey, Key, SlotMap};
@@ -296,6 +296,7 @@ impl super::Page for Page {
                         .spacing(space_xxs),
                     ),
                 )
+                .width(Length::Fill)
                 .on_press(Message::Select(id))
                 .class(if selected {
                     theme::Button::Link

--- a/src/page/location.rs
+++ b/src/page/location.rs
@@ -1,7 +1,7 @@
 use crate::{fl, page};
 use cosmic::cosmic_config::cosmic_config_derive::CosmicConfigEntry;
 use cosmic::cosmic_config::{self, Config, ConfigSet, CosmicConfigEntry};
-use cosmic::iced::Alignment;
+use cosmic::iced::{Alignment, Length};
 use cosmic::{Element, Task, cosmic_theme, theme, widget};
 use serde::{Deserialize, Serialize};
 
@@ -186,6 +186,7 @@ impl page::Page for Page {
                         .spacing(space_xxs),
                     ),
                 )
+                .width(Length::Fill)
                 .on_press(Message::Select(i))
                 .class(if selected {
                     theme::Button::Link


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

The language names are not already separated into two strings, so I'm not sure that it can be aligned to the left and right like the others, unless we manually split the string.
