### PR TITLE
i18n(is): complete Icelandic translation to 100% parity

### DIFF
--- a/i18n/is/cosmic_initial_setup.ftl
+++ b/i18n/is/cosmic_initial_setup.ftl
@@ -17,3 +17,75 @@ type-to-search = Sláðu inn til að leita…
 timezone-and-location-page = Tímabelti og staðsetning
     .search-the-closest-major-city = Leita að nálægustu stórborg...
     .geonames-attribution = Listanum er raðað eftir íbúafjölda borganna. Gögn: geonames.org (leyfi frá CC-BY-4.0).
+
+accessibility-page = Uppsetning aðgengis
+    .display-scaling = Kvörðun skjás
+    .scale = Kvarði
+    .scale-options = Fleiri kvörðunarvalkostir
+    .screen-reader = Skjálesari
+    .interface-size = Stærð viðmóts
+    .magnifier = Stækkunargler
+    .magnifier-description = Eða notaðu flýtilykla:
+        Super + = til að auka aðdrátt, Super + - til að minnka aðdrátt,
+        Super + skrun með músinni
+
+# SelectLanguagePage
+create-account-page = Stofnaðu reikninginn þinn
+    .full-name = Fullt nafn
+    .user-name = Notandanafn
+    .user-name-note = Þetta verður notað sem heiti á heimamöppunni þinni og ekki er hægt að breyta því.
+    .dialog-add = Bæta við
+    .profile-add = Veldu prófílmynd
+    .invalid-username = Ógilt notandanafn
+    .password-mismatch = Lykilorð og staðfesting verða að vera eins
+
+# LocationPage
+appearance-page = Sérsníddu útlitið
+    .description = Þú getur sérsniðið áhersluliti og útlit skjáborðsins nánar í útlitsstillingunum.
+    .effects = Sjónbrellur
+    .frosted-glass = Móðugler
+    .frosted-description = Á við um stikur, smáforrit, glugga og kerfisviðmót
+    .effects-tip = Þú getur sérsniðið áhersluliti og útlit skjáborðsins nánar í útlitsstillingunum.
+    .tip = Ábending:
+    
+# LayoutPage
+layout-page = Stillingar framsetningar
+    .bottom-panel = Stika neðst
+    .top-panel-and-dock = Stika efst og dokka
+    .description = Færðu stikuna eða dokkuna á hvaða brún sem er, breyttu stærð þeirra og faldu þær sjálfkrafa í Stillingum.
+
+# SystemAppsPage
+new-apps-page = Ný kerfisforrit
+    .description = Njóttu fjölda nýrra kerfisforrita sem fylgja COSMIC-skjáborðsumhverfinu. Þar á meðal Stillingar, COSMIC-forritaverslun, Skráastjóri, Textaritill og Skjáhermir.
+
+# NewKeyboardShortcutsPage
+new-shortcuts-page = Nýir flýtilyklar
+    .description = Notaðu Shift + Super + örvar, eða dragðu með bendlinum, til að færa glugga. Nýttu þér sjónrænu vísbendingarnar þegar sjálfvirk reitaröðun glugga er notuð.
+
+# WorkflowPage
+workflow-page = Vinnusvæði fyrir vinnuflæðið þitt
+    .description = Láttu glugga fljóta eða reitaraðaðu þeim sjálfkrafa fyrir hvert vinnusvæði með reitaröðunarsmáforritinu.
+        Þú getur valið lóðrétt eða lárétt vinnusvæði. Þú getur einnig fest vinnusvæði til að gera þau föst.
+
+# LauncherPage
+launcher-page = Hratt og skilvirkt
+    .description = Ýttu á Super-lykilinn (eða Windows-lykilinn) til að virkja forritaræsinn. Leitaðu og ýttu á Enter til að opna forrit eða skipta yfir í það. Þú getur einnig farið beint í stillingar eða kerfisaðgerðir eins og svæfingu. Sláðu inn „?“ til að fræðast um ítarlega eiginleika forritaræsisins.
+
+# WirelessPage
+wireless-page = Náðu tengingu
+    .explain = Þegar tengingu er náð færðu nýjustu kerfis- og öryggisuppfærslurnar.
+    .airplane-mode = Kveikt á flugstillingu
+    .connect = Tengjast
+    .connected = Tengt
+    .connecting = Tengist…
+    .disconnect = Aftengjast
+    .forget = Gleyma
+    .no-networks = Engin net fundust
+    .known-networks = Þekkt net
+    .visible-networks = Sýnileg net
+auth-dialog = Auðkenningar krafist
+    .wifi-description = Sláðu inn lykilorðið eða dulkóðunarlykilinn. Þú getur einnig tengst með því að ýta á „WPS“-hnappinn á beininum.
+users = Notendur
+    .desc = Auðkenning og notendareikningar.
+    .admin = Stjórnandi
+    .standard = Venjulegur


### PR DESCRIPTION
Completes the Icelandic (`is`) localization to 100% key parity with `en`.

Terminology grounded in Íðorðabankinn (the TOLVA computing dictionary, Árnastofnun) and made consistent with COSMIC's existing Icelandic translations. Fluent placeables, selector keys, attributes, and proper nouns are preserved; only human-readable text was translated. Validated with `fluent.syntax` (no Junk) and full en/is key-parity checks.