### PR TITLE
Remove unnecessary APT icon dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,10 +20,6 @@ Package: cosmic-initial-setup
 Architecture: amd64 arm64
 Depends:
     appstream-data-pop,
-    apt-config-icons,
-    apt-config-icons-hidpi,
-    apt-config-icons-large,
-    apt-config-icons-large-hidpi,
     cosmic-icons,
     ${misc:Depends},
     ${shlibs:Depends}


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Remove the following packages from `cosmic-initial-setup` dependencies:

* `apt-config-icons`
* `apt-config-icons-hidpi`
* `apt-config-icons-large`
* `apt-config-icons-large-hidpi`

These packages are not referenced anywhere in the cosmic-initial-setup source code and are only declared as explicit Debian package dependencies in debian/control.

Removing them prevents cosmic-initial-setup from pulling in unnecessary APT icon configuration packages.

Related to [cosmic-store#600](https://github.com/pop-os/cosmic-store/pull/600).
